### PR TITLE
Introducing DialogReferenceManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Updated React 15.2.1 to version 15.3.1
 * Updated React Native 0.31.0 to version 0.32.0
 * Updated PropTypes declaration to correct array
+* **NEW** DialogReferenceManager
 
 ### 0.6.0 (August 19, 2016)
 * Forked from react-native-popup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Updated React Native 0.31.0 to version 0.32.0
 * Updated PropTypes declaration to correct array
 * **NEW** DialogReferenceManager
+* PropTypes missing from DialogBox have been added
 
 ### 0.6.0 (August 19, 2016)
 * Forked from react-native-popup

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This is a custom component for React Native, a simple popup, compatible with ios
 ![ui](./ui.gif)
 
 ###Props
+- <b>name</b> *string* - unique name to register component with DialogReferenceManager
 - <b>isOverlay</b> *bool* - *`default true`*
 - <b>isOverlayClickClose</b> *bool* - *`default true`*
 

--- a/README.md
+++ b/README.md
@@ -119,3 +119,53 @@ export default class App extends Component{
 
 };
 ```
+
+###Example working with DialogReferenceManager
+
+###Outer container
+```javascript
+import React, { Component } from 'react';
+import { View, StyleSheet } from 'react-native';
+import DialogBox from 'react-native-dialogbox';
+
+export default class App extends Component {
+	render() {
+		return (
+			<View style={styles.app}>
+				<MyComponent />
+				<DialogBox name="default" />
+			</View>
+		);
+	}
+}
+```
+
+###Sub component
+```javascript
+import React, { Component } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { DialogReferenceManager } from 'react-native-dialogbox';
+
+export default class MyComponent extends Component {
+	handleOnPress = () => {
+		DialogReferenceManager.dialog('default').alert(1);
+	}
+
+	render() {
+		return (
+			<View style={styles.container}>
+				<Text style={styles.btn} onPress={this.handleOnPress}>click me !</Text>
+			</View>
+		)
+	}
+}
+```
+
+DialogReferenceManager allows you to access instances of the DialogBox that exist elsewhere in the render chain. It requires that the name property be set on the DialogBox. Shortcut handlers for `alert`, `tip`, `confirm`, and `close` are available for the component registered as `default` as such:
+
+```javascript
+DialogReferenceManager.alert(1); // only works if a component exists named 'default'
+DialogReferenceManager.dialog('AnyName').alert(1); // allows to access any named dialogbox
+```
+
+This feature was implemented due to the way that absolute positioning works. Users wanted to call a dialogbox in code, but it required the component to be registered at the top of the render chain.

--- a/index.js
+++ b/index.js
@@ -12,6 +12,93 @@ import {
 	Platform,
 } from 'react-native';
 
+const _references = new WeakMap();
+
+class DialogReferenceManager {
+	constructor() {
+		_references.set(this, {});
+	}
+
+	register(name, component) {
+		if (component === void 0) {
+			throw new Error('A DialogBox component is required to register it with the registry');
+		}
+		if (typeof name === 'string' && name.length > 0) {
+			const storage = _references(this);
+			if (storage) {
+				if (storage[name] === void 0) {
+					storage[name] = component;
+					_references.set(this, storage);
+				} else {
+					throw new Error('A dialogbox with the name "' + name + '" was previously registered. Names must be unique and only one can act as "default"');
+				}
+			}
+		} else {
+			throw new Error('Attempt to register a dialogbox without a name occurred');
+		}
+	}
+
+	unregister(name) {
+		if (typeof name === 'string' && name.length > 0) {
+			const storage = _references(this);
+			if (storage && storage[name]) {
+				delete storage[name];
+				_references.set(this, storage);
+			}
+		} else {
+			throw new Error('Attempt to unregister a dialogbox without a name occurred');
+		}
+	}
+
+	dialogbox(name) {
+		const id = (typeof name === 'string' && name.length > 0) ? name : 'default';
+		const storage = _references(this);
+		if (storage && storage[id]) {
+			return storage[id];
+		}
+		return void 0;
+	}
+
+	alert(...text) {
+		const component = this.dialogbox('default');
+		if (component) {
+			component.alert(...text);
+		} else {
+			console.warn('An alert request to the default dialogbox was made, but no dialogbox was registered as default');
+		}
+	}
+
+	tip(args) {
+		const component = this.dialogbox('default');
+		if (component) {
+			component.tip(args);
+		} else {
+			console.warn('A tip request to the default dialogbox was made, but no dialogbox was registered as default');
+		}
+	}
+
+	confirm(args) {
+		const component = this.dialogbox('default');
+		if (component) {
+			component.confirm(args);
+		} else {
+			console.warn('A confirm request to the default dialogbox was made, but no dialogbox was registered as default');
+		}
+	}
+
+	close() {
+		const component = this.dialogbox('default');
+		if (component) {
+			component.close();
+		} else {
+			console.warn('A close request to the default dialogbox was made, but no dialogbox was registered as default');
+		}
+	}
+}
+
+const dialogReferenceManager = Object.freeze(new DialogReferenceManager());
+export { dialogReferenceManager as DialogReferenceManager }
+
 class PopContent extends Component{
 
 	static propTypes = {
@@ -145,6 +232,10 @@ export default class DialogBox extends Component{
 
 	static DisplayPopup = DisplayPopup;
 
+	static propTypes = {
+		name: PropTypes.string
+	};
+
 	static defaultProps = {
 		isOverlay: true,
 		isOverlayClickClose: true,
@@ -159,6 +250,29 @@ export default class DialogBox extends Component{
 			isOverlayClickClose: this.props.isOverlayClickClose,
 			content: null,
 		};
+	}
+
+	componentDidMount() {
+		if (this.props.name) {
+			dialogReferenceManager.register(this.props.name, this);
+		}
+	}
+
+	componentWillUnmount() {
+		if (this.props.name) {
+			dialogReferenceManager.unregister(this.props.name);
+		}
+	}
+
+	componentWillReceiveProps(nextProps) {
+		if (this.props.name !== nextProps.name) {
+			if (this.props.name) {
+				dialogReferenceManager.unregister(this.props.name);
+			}
+			if (nextProps.name) {
+				dialogReferenceManager.register(nextProps.name, this);
+			}
+		}
 	}
 
 	_pop(args) {

--- a/index.js
+++ b/index.js
@@ -233,7 +233,9 @@ export default class DialogBox extends Component{
 	static DisplayPopup = DisplayPopup;
 
 	static propTypes = {
-		name: PropTypes.string
+		name: PropTypes.string,
+		isOverlay: PropTypes.bool,
+		isOverlayClickClose: PropTypes.bool
 	};
 
 	static defaultProps = {


### PR DESCRIPTION
## New Exported Component

DialogReferenceManager allows for access to DialogBox instances no matter where they are placed in the render tree. This registry was created so that a DialogBox can be placed at the root and child components can activate it with ease.
### Changes Required for Use

When adding a DialogBox (preferably at the bottom of a root view) the new `name` property must be set. If only one dialog will be used, the name should be set to `default`.
### Usage By Child Components

A Component that wants to make use of a Dialog located elsewhere, simply needs to import the following:

``` javascript
import { DialogReferenceManager } from 'react-native-dialogbox';
```

Usage for a named `default` component works just like talking to the original.

``` javascript
DialogReferenceManager.alert(1);
```

To access a component named something other than `default`, you would access it via dialog:

``` javascript
DialogReferenceManager.dialog('somename').alert(1);
```
### Closing

The DialogBox component handles the registration and deregistration of itself with DialogReferenceManager. The only requirement for its use it the `name` property being set.
