### PR TITLE
Update for React Native 0.53

### DIFF
--- a/lib/DisplayPopup.js
+++ b/lib/DisplayPopup.js
@@ -7,7 +7,7 @@ import makeStyleProxy from './make-stylesheet';
 
 export default class DisplayPopup extends Component {
 
-	static PropTypes = {
+	static propTypes = {
 		isOverlay: PropTypes.bool,
 		isOverlayClickClose: PropTypes.bool,
 		onDismiss: PropTypes.func,

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ export default class DialogBox extends Component {
 
 	static DisplayPopup = DisplayPopup;
 
-	static PropTypes = {
+	static propTypes = {
 		isOverlay: PropTypes.bool,
 		isOverlayClickClose: PropTypes.bool,
 		onDismiss: PropTypes.func,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-dialogbox",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "dialog popup for react-native",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/victoriafrench/react-native-dialogbox#readme",
   "peerDependencies": {
     "react": "*",
-    "react-native": ">=0.30.0 < 0.51.0"
+    "react-native": ">=0.30.0 < 0.54.0"
   },
   "dependencies": {
     "prop-types": "^15.6.0"


### PR DESCRIPTION
Bumped compatibility with RN to 0.53 (I've tested it in my app and it works) and renamed PropTypes to propTypes in two classes to avoid new RN warnings.

Fix #63 