### PR TITLE
Works fine in React Native 0.57

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/victoriafrench/react-native-dialogbox#readme",
   "peerDependencies": {
     "react": "*",
-    "react-native": ">=0.30.0 < 0.54.0"
+    "react-native": ">=0.30.0"
   },
   "dependencies": {
     "prop-types": "^15.6.0"


### PR DESCRIPTION
The module works fine in RN 0.57 so, as a suggestion, I've removed the upper check for RN version. Basically instead of assuming it will break in future version, we assume it will work and that way we don't have to update package.json. If it breaks any way we can probably easily fix the module since there's no native code.